### PR TITLE
Cmake add includes

### DIFF
--- a/cmake_macros/add_dependencies.cmake
+++ b/cmake_macros/add_dependencies.cmake
@@ -1,55 +1,40 @@
+INCLUDE(FindPkgConfig)
 
+set(ENV{PKG_CONFIG_PATH} "${CMAKE_INSTALL_PREFIX}/lib/pkgconfig/")
 
-
-  set(ENV{PKG_CONFIG_PATH} "${CMAKE_INSTALL_PREFIX}/lib/pkgconfig/")
-  INCLUDE(FindPkgConfig)
-
-  message(%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%)
-  message(%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%)
-  message("Add deps info for: ${PARTITION} - ${MODULES}" )
-  message("architecture: ${CMAKE_LIBRARY_ARCHITECTURE}")
-  message("system_prefix: ${CMAKE_SYSTEM_PREFIX_PATH}")
-
-  message(%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%)
-  message(%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%)
-  message(%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%)
-
-  #set(CMAKE_SYSTEM_PREFIX_PATH /usr/local;/usr;/;/usr;/root/esrocos_workspace/install)
-  #set(CMAKE_LIBRARY_ARCHITECTURE x86_64-linux-gnu)
-
-  set(LOCAL_LIBS_WO "${PARTITION}:")
-  set(LOCAL_INCL_WO "${PARTITION}:")
+set(LOCAL_LIBS_WO "${PARTITION}:")
+set(LOCAL_INCL_WO "${PARTITION}:")
  
-  string(REPLACE " " ";" MODULES ${MODULES})
-  string(REPLACE " " ";" CMAKE_SYSTEM_PREFIX_PATH ${CMAKE_SYSTEM_PREFIX_PATH})
+string(REPLACE " " ";" MODULES ${MODULES})
+string(REPLACE " " ";" CMAKE_SYSTEM_PREFIX_PATH ${CMAKE_SYSTEM_PREFIX_PATH})
 
-  foreach(MODULE ${MODULES}) 
+foreach(MODULE ${MODULES}) 
     
-    pkg_check_modules(${MODULE}_INFO REQUIRED ${MODULE})
+  pkg_check_modules(${MODULE}_INFO REQUIRED ${MODULE})
 
-    foreach(LIB ${${MODULE}_INFO_STATIC_LIBRARIES})
+  foreach(LIB ${${MODULE}_INFO_STATIC_LIBRARIES})
     
     set(NOT_INCLUDED 1)
       
-      foreach(DIR ${${MODULE}_INFO_STATIC_LIBRARY_DIRS})
-        if(EXISTS "${DIR}/lib${LIB}.a") 
-          set(LOCAL_LIBS_WO "${LOCAL_LIBS_WO}\n- ${DIR}/lib${LIB}.a")
-	  set(NOT_INCLUDED 0)
-        elseif(EXISTS "${DIR}/lib${LIB}.so") 
-          set(LOCAL_LIBS_WO "${LOCAL_LIBS_WO}\n- ${DIR}/lib${LIB}.so")
-	  set(NOT_INCLUDED 0)
-        endif()   
-      endforeach(DIR)
+    foreach(DIR ${${MODULE}_INFO_STATIC_LIBRARY_DIRS})
+      if(EXISTS "${DIR}/lib${LIB}.a") 
+        set(LOCAL_LIBS_WO "${LOCAL_LIBS_WO}\n- ${DIR}/lib${LIB}.a")
+        set(NOT_INCLUDED 0)
+      elseif(EXISTS "${DIR}/lib${LIB}.so") 
+        set(LOCAL_LIBS_WO "${LOCAL_LIBS_WO}\n- ${DIR}/lib${LIB}.so")
+        set(NOT_INCLUDED 0)
+      endif()   
+    endforeach(DIR)
 
-      if(${NOT_INCLUDED})
-        message("library ${LIB} not found, try in standard locations")
-	find_library(FOUND ${LIB})
-	message("found ${LIB}: ${FOUND}")
-        if(EXISTS ${FOUND})
-          set(LOCAL_LIBS_WO "${LOCAL_LIBS_WO}\n- ${FOUND}" )
-        endif()
-        unset (FOUND CACHE)
+    if(${NOT_INCLUDED})
+      message("library ${LIB} not found, try in standard locations")
+      find_library(FOUND ${LIB})
+      message("found ${LIB}: ${FOUND}")
+      if(EXISTS ${FOUND})
+        set(LOCAL_LIBS_WO "${LOCAL_LIBS_WO}\n- ${FOUND}" )
       endif()
+        unset (FOUND CACHE)
+     endif()
 
     endforeach(LIB)
     
@@ -62,16 +47,5 @@
   set(LOCAL_LIBS_WO "${LOCAL_LIBS_WO}\n" )
   set(LOCAL_INCL_WO "${LOCAL_INCL_WO}\n" )
 
-  message(%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%)
-  message(%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%)
-  message(${LOCAL_INCL_WO})
-  message(%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%)
-  message(%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%)
-  message(${LOCAL_LIBS_WO})
-  message(%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%)
-  message(%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%)
-
   file(APPEND ${CMAKE_BINARY_DIR}/includes.yml ${LOCAL_INCL_WO})
   file(APPEND ${CMAKE_BINARY_DIR}/linkings.yml ${LOCAL_LIBS_WO})
-
-

--- a/cmake_macros/add_dependencies.cmake
+++ b/cmake_macros/add_dependencies.cmake
@@ -1,0 +1,77 @@
+
+
+
+  set(ENV{PKG_CONFIG_PATH} "${CMAKE_INSTALL_PREFIX}/lib/pkgconfig/")
+  INCLUDE(FindPkgConfig)
+
+  message(%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%)
+  message(%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%)
+  message("Add deps info for: ${PARTITION} - ${MODULES}" )
+  message("architecture: ${CMAKE_LIBRARY_ARCHITECTURE}")
+  message("system_prefix: ${CMAKE_SYSTEM_PREFIX_PATH}")
+
+  message(%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%)
+  message(%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%)
+  message(%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%)
+
+  #set(CMAKE_SYSTEM_PREFIX_PATH /usr/local;/usr;/;/usr;/root/esrocos_workspace/install)
+  #set(CMAKE_LIBRARY_ARCHITECTURE x86_64-linux-gnu)
+
+  set(LOCAL_LIBS_WO "${PARTITION}:")
+  set(LOCAL_INCL_WO "${PARTITION}:")
+ 
+  string(REPLACE " " ";" MODULES ${MODULES})
+  string(REPLACE " " ";" CMAKE_SYSTEM_PREFIX_PATH ${CMAKE_SYSTEM_PREFIX_PATH})
+
+  foreach(MODULE ${MODULES}) 
+    
+    pkg_check_modules(${MODULE}_INFO REQUIRED ${MODULE})
+
+    foreach(LIB ${${MODULE}_INFO_STATIC_LIBRARIES})
+    
+    set(NOT_INCLUDED 1)
+      
+      foreach(DIR ${${MODULE}_INFO_STATIC_LIBRARY_DIRS})
+        if(EXISTS "${DIR}/lib${LIB}.a") 
+          set(LOCAL_LIBS_WO "${LOCAL_LIBS_WO}\n- ${DIR}/lib${LIB}.a")
+	  set(NOT_INCLUDED 0)
+        elseif(EXISTS "${DIR}/lib${LIB}.so") 
+          set(LOCAL_LIBS_WO "${LOCAL_LIBS_WO}\n- ${DIR}/lib${LIB}.so")
+	  set(NOT_INCLUDED 0)
+        endif()   
+      endforeach(DIR)
+
+      if(${NOT_INCLUDED})
+        message("library ${LIB} not found, try in standard locations")
+	find_library(FOUND ${LIB})
+	message("found ${LIB}: ${FOUND}")
+        if(EXISTS ${FOUND})
+          set(LOCAL_LIBS_WO "${LOCAL_LIBS_WO}\n- ${FOUND}" )
+        endif()
+        unset (FOUND CACHE)
+      endif()
+
+    endforeach(LIB)
+    
+    foreach(DIR ${${MODULE}_INFO_INCLUDE_DIRS})
+      set(LOCAL_INCL_WO "${LOCAL_INCL_WO}\n- ${DIR}")
+    endforeach(DIR)
+
+  endforeach(MODULE)
+
+  set(LOCAL_LIBS_WO "${LOCAL_LIBS_WO}\n" )
+  set(LOCAL_INCL_WO "${LOCAL_INCL_WO}\n" )
+
+  message(%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%)
+  message(%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%)
+  message(${LOCAL_INCL_WO})
+  message(%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%)
+  message(%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%)
+  message(${LOCAL_LIBS_WO})
+  message(%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%)
+  message(%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%)
+
+  file(APPEND ${CMAKE_BINARY_DIR}/includes.yml ${LOCAL_INCL_WO})
+  file(APPEND ${CMAKE_BINARY_DIR}/linkings.yml ${LOCAL_LIBS_WO})
+
+

--- a/cmake_macros/esrocos.cmake
+++ b/cmake_macros/esrocos.cmake
@@ -8,7 +8,8 @@ macro(esrocos_init)
   set(ENV{PKG_CONFIG_PATH} "${CMAKE_INSTALL_PREFIX}/lib/pkgconfig/")
 
   file(WRITE ${CMAKE_BINARY_DIR}/linkings.yml "")
-
+  file(WRITE ${CMAKE_BINARY_DIR}/includes.yml "")
+  
   # PkgConfig
   INCLUDE(FindPkgConfig)
  
@@ -31,7 +32,7 @@ endmacro(esrocos_init)
 function(esrocos_export_function FUNCTION_DIR INSTALL_DIR)
 
   add_custom_target(create_install_dir ALL 
-                  COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_INSTALL_PREFIX}/${INSTALL_DIR})
+                   COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_INSTALL_PREFIX}/${INSTALL_DIR})
   add_custom_target(create_zip ALL
                   COMMAND ${CMAKE_COMMAND} -E tar "cfv" "${CMAKE_BINARY_DIR}/${FUNCTION_DIR}.zip" "--format=zip" "${FUNCTION_DIR}"
 		  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
@@ -50,7 +51,7 @@ function(esrocos_export_pkgconfig)
   cmake_parse_arguments(esrocos_export_pkgconfig "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
 
   SET(PROJECT_NAME ${CMAKE_PROJECT_NAME})
-  SET(PKG_CONFIG_REQUIRES ${esrocos_export_pkgconfig_REQUIRES})
+  SET(PKG_CONFIG_REQUIRES "${esrocos_export_pkgconfig_REQUIRES}")
   SET(VERSION ${esrocos_export_pkgconfig_VERSION})
   SET(DESCRIPTION ${esrocos_export_pkgconfig_DESCRIPTION})
   SET(PKG_CONFIG_CFLAGS ${esrocos_export_pkgconfig_CFLAGS})
@@ -73,10 +74,10 @@ add_custom_command(
     TARGET ESROCOS_BUILD_PROJECT 
     POST_BUILD
     COMMAND ${CMAKE_COMMAND}
-    ARGS -P ${CMAKE_INSTALL_PREFIX}/cmake_macros/build_project.cmake
+    ARGS
+    -P ${CMAKE_INSTALL_PREFIX}/cmake_macros/build_project.cmake
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 )
-
 
 endfunction(esrocos_build_project)
  
@@ -86,50 +87,30 @@ function(esrocos_add_dependency)
 
   cmake_parse_arguments(esrocos_add_dependency "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
 
-  set(LOCAL_LIBS_WO "${esrocos_add_dependency_PARTITION}:")
-  set(LOCAL_INCL_WO "${esrocos_add_dependency_PARTITION}:")
-  
 
-  foreach(MODULE ${esrocos_add_dependency_MODULES}) 
-    
-    
-    pkg_check_modules(${MODULE}_INFO REQUIRED ${MODULE})
-     
+  add_custom_target(${esrocos_add_dependency_PARTITION}_deps ALL)
 
-    foreach(LIB ${${MODULE}_INFO_STATIC_LIBRARIES})
+  add_dependencies(${esrocos_add_dependency_PARTITION}_deps init_esrocos)
 
-      set(NOT_INCLUDED TRUE)
-      foreach(DIR ${${MODULE}_INFO_STATIC_LIBRARY_DIRS})
-        if(EXISTS "${DIR}/lib${LIB}.a") 
-          set(LOCAL_LIBS_WO "${LOCAL_LIBS_WO}\n- ${DIR}/lib${LIB}.a")
-          set(NOT_INCLUDED FALSE)
-        elseif(EXISTS "${DIR}/lib${LIB}.so") 
-          set(LOCAL_LIBS_WO "${LOCAL_LIBS_WO}\n- ${DIR}/lib${LIB}.so")
-          set(NOT_INCLUDED FALSE)
-        endif()   
-      endforeach(DIR)
+  add_custom_command( 
+    TARGET ${esrocos_add_dependency_PARTITION}_deps
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} 
+    ARGS
+      -D CMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+      -D CMAKE_FIND_LIBRARY_PREFIXES=${CMAKE_FIND_LIBRARY_PREFIXES}
+      -D CMAKE_FIND_LIBRARY_SUFFIXES=${CMAKE_FIND_LIBRARY_SUFFIXES}
 
-      if(${NOT_INCLUDED})
-        find_library(FOUND ${LIB})
-        if(EXISTS ${FOUND})
-          set(LOCAL_LIBS_WO "${LOCAL_LIBS_WO}\n- ${FOUND}" )
-        endif()
-        unset (FOUND CACHE)
-      endif()
-    endforeach(LIB)
-    
-    foreach(C_FLAG ${${MODULE}_INFO_INCLUDE_DIRS})
-   
-      set(LOCAL_INCL_WO "${LOCAL_INCL_WO}\n- ${C_FLAG}")
-    endforeach(C_FLAG)
-   
-  endforeach(MODULE)
+      -D CMAKE_SYSTEM_PREFIX_PATH="${CMAKE_SYSTEM_PREFIX_PATH}"  
+      -D CMAKE_LIBRARY_ARCHITECTURE=${CMAKE_LIBRARY_ARCHITECTURE}
+      
+      -D PARTITION=${esrocos_add_dependency_PARTITION}  
+      -D MODULES="${esrocos_add_dependency_MODULES}" 
 
-  set(LOCAL_LIBS_WO "${LOCAL_LIBS_WO}\n" )
-  set(LOCAL_INCL_WO "${LOCAL_INCL_WO}\n" )
-
-  file(APPEND ${CMAKE_BINARY_DIR}/includes.yml ${LOCAL_INCL_WO})
-  file(APPEND ${CMAKE_BINARY_DIR}/linkings.yml ${LOCAL_LIBS_WO})
+      -P ${CMAKE_INSTALL_PREFIX}/cmake_macros/add_dependencies.cmake
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    USES_TERMINAL
+   )
 
 endfunction(esrocos_add_dependency)
 

--- a/cmake_macros/esrocos.cmake
+++ b/cmake_macros/esrocos.cmake
@@ -89,14 +89,17 @@ function(esrocos_add_dependency)
   set(LOCAL_LIBS_WO "${esrocos_add_dependency_PARTITION}:")
   set(LOCAL_INCL_WO "${esrocos_add_dependency_PARTITION}:")
   
-  foreach(MODULE ${esrocos_add_dependency_MODULES})
 
-    pkg_check_modules(INFO REQUIRED ${MODULE})
+  foreach(MODULE ${esrocos_add_dependency_MODULES}) 
+    
+    
+    pkg_check_modules(${MODULE}_INFO REQUIRED ${MODULE})
+     
 
-    foreach(LIB ${INFO_STATIC_LIBRARIES})
-   
+    foreach(LIB ${${MODULE}_INFO_STATIC_LIBRARIES})
+
       set(NOT_INCLUDED TRUE)
-      foreach(DIR ${LINK_LIBS_STATIC_LIBRARY_DIRS})
+      foreach(DIR ${${MODULE}_INFO_STATIC_LIBRARY_DIRS})
         if(EXISTS "${DIR}/lib${LIB}.a") 
           set(LOCAL_LIBS_WO "${LOCAL_LIBS_WO}\n- ${DIR}/lib${LIB}.a")
           set(NOT_INCLUDED FALSE)
@@ -115,11 +118,15 @@ function(esrocos_add_dependency)
       endif()
     endforeach(LIB)
     
-    foreach(INCLUDE ${INFO_STATIC_INCLUDE_DIRS})
-      set(LOCAL_INCL_WO "${LOCAL_INCL_WO}\n- $INCLUDE}")
-    endforeach(INCLUDE)
-    
+    foreach(C_FLAG ${${MODULE}_INFO_INCLUDE_DIRS})
+   
+      set(LOCAL_INCL_WO "${LOCAL_INCL_WO}\n- ${C_FLAG}")
+    endforeach(C_FLAG)
+   
   endforeach(MODULE)
+
+  set(LOCAL_LIBS_WO "${LOCAL_LIBS_WO}\n" )
+  set(LOCAL_INCL_WO "${LOCAL_INCL_WO}\n" )
 
   file(APPEND ${CMAKE_BINARY_DIR}/includes.yml ${LOCAL_INCL_WO})
   file(APPEND ${CMAKE_BINARY_DIR}/linkings.yml ${LOCAL_LIBS_WO})

--- a/cmake_macros/esrocos.cmake
+++ b/cmake_macros/esrocos.cmake
@@ -86,21 +86,22 @@ function(esrocos_add_dependency)
 
   cmake_parse_arguments(esrocos_add_dependency "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
 
-  set(LOCAL_WO "${esrocos_add_dependency_PARTITION}:")
+  set(LOCAL_LIBS_WO "${esrocos_add_dependency_PARTITION}:")
+  set(LOCAL_INCL_WO "${esrocos_add_dependency_PARTITION}:")
   
   foreach(MODULE ${esrocos_add_dependency_MODULES})
 
-    pkg_check_modules(LINK_LIBS REQUIRED ${MODULE})
+    pkg_check_modules(INFO REQUIRED ${MODULE})
 
-    foreach(LIB ${LINK_LIBS_STATIC_LIBRARIES})
+    foreach(LIB ${INFO_STATIC_LIBRARIES})
    
       set(NOT_INCLUDED TRUE)
       foreach(DIR ${LINK_LIBS_STATIC_LIBRARY_DIRS})
         if(EXISTS "${DIR}/lib${LIB}.a") 
-          set(LOCAL_WO "${LOCAL_WO}\n- ${DIR}/lib${LIB}.a")
+          set(LOCAL_LIBS_WO "${LOCAL_LIBS_WO}\n- ${DIR}/lib${LIB}.a")
           set(NOT_INCLUDED FALSE)
         elseif(EXISTS "${DIR}/lib${LIB}.so") 
-          set(LOCAL_WO "${LOCAL_WO}\n- ${DIR}/lib${LIB}.so")
+          set(LOCAL_LIBS_WO "${LOCAL_LIBS_WO}\n- ${DIR}/lib${LIB}.so")
           set(NOT_INCLUDED FALSE)
         endif()   
       endforeach(DIR)
@@ -108,14 +109,20 @@ function(esrocos_add_dependency)
       if(${NOT_INCLUDED})
         find_library(FOUND ${LIB})
         if(EXISTS ${FOUND})
-          set(LOCAL_WO "${LOCAL_WO}\n- ${FOUND}" )
+          set(LOCAL_LIBS_WO "${LOCAL_LIBS_WO}\n- ${FOUND}" )
         endif()
         unset (FOUND CACHE)
       endif()
     endforeach(LIB)
+    
+    foreach(INCLUDE ${INFO_STATIC_INCLUDE_DIRS})
+      set(LOCAL_INCL_WO "${LOCAL_INCL_WO}\n- $INCLUDE}")
+    endforeach(INCLUDE)
+    
   endforeach(MODULE)
 
-  file(APPEND ${CMAKE_BINARY_DIR}/linkings.yml ${LOCAL_WO})
+  file(APPEND ${CMAKE_BINARY_DIR}/includes.yml ${LOCAL_INCL_WO})
+  file(APPEND ${CMAKE_BINARY_DIR}/linkings.yml ${LOCAL_LIBS_WO})
 
 endfunction(esrocos_add_dependency)
 


### PR DESCRIPTION
Adds the generation of a includes.yml in addition to the linkings.yml to add include dirs to the orchestrator_options